### PR TITLE
Add link to Stroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A collective of gardeners publicly tending their digital notes on the interwebs
 ## Tools and Resources
 
 - [TiddlyWiki](https://tiddlywiki.com/)
+- [Stroll](https://giffmex.org/stroll/stroll.html)
 - [Gatsby Brain Theme](https://github.com/aengusmcmillin/gatsby-theme-brain) - Roam-like bidirectional links in Gatsby.js
 - [Hypothesis](https://web.hypothes.is/) - social meta commentary
 - [Org Roam](https://org-roam.readthedocs.io/en/develop/installation/)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A collective of gardeners publicly tending their digital notes on the interwebs
 
 ## Tools and Resources
 
-- [TiddlyWiki](https://tiddlywiki.com/)
-- [Stroll](https://giffmex.org/stroll/stroll.html)
+- [TiddlyWiki](https://tiddlywiki.com/) - A no-code personal wiki system
+- [Stroll](https://giffmex.org/stroll/stroll.html) - A Roam-like tool built on TiddlyWiki
 - [Gatsby Brain Theme](https://github.com/aengusmcmillin/gatsby-theme-brain) - Roam-like bidirectional links in Gatsby.js
 - [Hypothesis](https://web.hypothes.is/) - social meta commentary
 - [Org Roam](https://org-roam.readthedocs.io/en/develop/installation/)


### PR DESCRIPTION
Stroll is built on top of TiddlyWiki and emulates a lot of the functionality of Roam.