### PR TITLE
add new garden: Chinarut’s online autobiography

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ A collective of gardeners publicly tending their digital notes on the interwebs
 | [Fabien Benetou](https://fabien.benetou.fr/) | PmWiki (with plenty of extensions PHP/JS/NodeJS/WebXR/CSS/Processing/etc) | Everytyhing but particularly programming, tools, tools for thoughts |
 | [Waylon Walker](https://waylonwalker.com/notes) | Gatsby | python, data-engineering, coding, learning notes |
 | [Cristian Rojas](https://notes.crisrojas.com) | [Hugo Zettels theme](https://github.com/crisrojas/zettels) | 🇪🇸 Drawing, coding, biology, introspection |
+| [Chinarut Ruangchotvit](http://autobiography.chinarut.com) | TheBrain | autobiography, personal transformation |


### PR DESCRIPTION
add Chinarut’s online autobiography as a semi-structured approach to implementing TheBrain