### PR TITLE
add dendron to gardening tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A collective of gardeners publicly tending their digital notes on the interwebs
 
 #### Building a Public Garden
 
+- [Dendron](https://www.dendron.so/) - A structured note taking tool that merges the freedom of Roam-like linking with the order hierarchical organization  
 - [TiddlyWiki](https://tiddlywiki.com/) - A no-code personal wiki system
   - [Stroll](https://giffmex.org/stroll/stroll.html) a TiddlyWiki plugin with bi-directional links and other Roam-like features
   - [TiddlyMap](http://tiddlymap.org/) - a mind-map plugin that shows visualizations for TiddlyWiki.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ A collective of gardeners publicly tending their digital notes on the interwebs
 
 #### Building a Public Garden
 
-- [Dendron](https://www.dendron.so/) - A structured note taking tool that merges the freedom of Roam-like linking with the order hierarchical organization  
 - [TiddlyWiki](https://tiddlywiki.com/) - A no-code personal wiki system
   - [Stroll](https://giffmex.org/stroll/stroll.html) a TiddlyWiki plugin with bi-directional links and other Roam-like features
   - [TiddlyMap](http://tiddlymap.org/) - a mind-map plugin that shows visualizations for TiddlyWiki.
@@ -23,6 +22,7 @@ A collective of gardeners publicly tending their digital notes on the interwebs
 - [Digital Garden Jekyll Template](https://github.com/maximevaillancourt/digital-garden-jekyll-template) - A simple, clean jekyll template with bi-directional links
 - [Eleventy Garden](https://github.com/b3u/eleventy-garden) - A minimal template with backlinks, built in [Eleventy](https://11ty.dev)
 - [Foam](https://foambubble.github.io/foam/) - Roam-like personal note management and publishing system built inside VSCode
+- [Dendron](https://www.dendron.so/) - A structured note taking tool that merges the freedom of Roam-like linking with the order hierarchical organization  
 
 #### Building a Private Garden
 


### PR DESCRIPTION
add dendron to list of gardening tools. see hn thread [here](https://news.ycombinator.com/item?id=23890035) and website [here](http://dendron.so/). public garden example [here](http://kevinslin.com/)