### PR TITLE
Add Roam Garden and related information

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,15 @@ A collective of gardeners publicly tending their digital notes on the interwebs
 - [Dendron](https://www.dendron.so/) - A structured note taking tool that merges the freedom of Roam-like linking with the order hierarchical organization  
 - [Roam-to-Garden](https://github.com/DoomHammer/roam-to-git/tree/roam-to-garden) - Turns a [Roam Research](https://roamresearch.com/) database into a Digital Garden
 - [Hyperdraft](https://hyperdraft.rosano.ca) - Notes app that makes it simple to create a static site from plaintext / Markdown.
+- [Roam Garden](https://roam.garden/) - A service that allows you easily create beautifully tended Digital Gardens from your [Roam Research](https://roamresearch.com/) graph (no technical background needed).
 
 #### Building a Private Garden
 
 - [Roam Research](https://roamresearch.com/) - A personal notes system for interconnected thought
+  - See the following resources for converting your private garden in Roam to a public garden:
+    - [Roam Garden](https://roam.garden/) a service that does all the setup for you based on JSON export
+    - [Gatsby Theme Garden](https://github.com/mathieudutour/gatsby-digital-garden/) Gatsby theme that supports using Roam as a source
+    - [Roam-to-Garden](https://github.com/DoomHammer/roam-to-git/tree/roam-to-garden) Jekyll based converter for your Roam Data
 - [Org Roam](https://www.orgroam.com/) - non-hierarchical note-taking with org-mode in emacs
 - [Obsidian](https://obsidian.md/) - a Roam-like knowledge base that works on top of a local folder of plain text Markdown files.
 - [TheBrain](https://www.thebrain.com/) - A tool for taking interconnected notes with an interactive graph.
@@ -48,6 +53,7 @@ A collective of gardeners publicly tending their digital notes on the interwebs
 - [Install org-roam: an introductory technical guide with Doom Emacs](https://www.ianjones.us/2020-05-05-doom-emacs/) by Ian Jones
 - [Building a Digital Garden](https://tomcritchlow.com/2019/02/17/building-digital-garden/) by Tom Critchlow
 - [Webmentions - Joining the IndieWeb with Svelte](https://www.swyx.io/writing/clientside-webmentions) by Shawn Wang
+- [How to plant a Garden](https://www.loom.com/share/05ac911308554668a6b35fd2b321d3d9) a video walkthrough for converting your RoamResearch DB into a public garden by [Vlad Sitalo](https://twitter.com/VladyslavSitalo)
 
 <br />
 
@@ -124,3 +130,5 @@ A collective of gardeners publicly tending their digital notes on the interwebs
 | [Yenly Ma](https://yenly.wtf) | [Foamy NextJS](https://github.com/yenly/foamy-nextjs) and NextJS with MDX | Digital garden of gardens. Learning and making in public. |
 | [Rosano](https://rosano.hmm.garden) | Hyperdraft + [Garden](https://hmm.garden) | Music / Design / Technology |
 | [Chase McCoy](https://chasem.co/notes) | Gatsby + MDX | Web development, CSS, design systems |
+| [Vlad Sitalo](https://vlad.roam.garden/) | [Roam Garden](https://roam.garden/) | How to define code readability objectively? Applying SRS to all the things, Building Roam Garden |
+| [Joel Chan](https://joelchan.roam.garden/) | [Roam Garden](https://roam.garden/) | Knowledge synthesis, Scientific Creativity |


### PR DESCRIPTION
Hey Maggie!

This adds information about [Roam Garden](https://roam.garden/) - a service that allows you to convert Roam graph into a public digital garden. 

I'd really appreciate your feedback on it! (both on the conversion experience if you'd have a chance to try it & and on the results)

This PR also adds links to my (Vlad Sitalo) and [Joel Chan](https://twitter.com/JoelChan86)'s garden which are both based on Roam Garden
