### PR TITLE
Added brainfck.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,5 +155,6 @@ See the [Theory, Philosophy, and Navel-gazing](https://github.com/MaggieAppleton
 | [Clinton Boys](https://mtsolitary.com) | org-roam + Hugo | Writing, data science, math, life |
 | [David Ralph Lewis](https://notes.davidralphlewis.co.uk) | TiddlyWiki | Writing, poetry, wellbeing, psychology |
 | [Soren Bjornstad](https://zettelkasten.sorenbjornstad.com) | TiddlyWiki + homegrown scripts | Almost everything; emphasis on tech, reading, and how to live |
+| [Victor Dorneanu](https://brainfck.org) | [TiddlyWiki](https://tiddlywiki.com/), [ORG Mode](https://orgmode.org/) | Personal Zettelkasten for almost everything: Book/Podcast notes, bookmarks, code snippets, quotes, Security, Golang, Python, ... |
 | [Paul Batchelor](https://pbat.ch/wiki) | [WeeWiki](https://pbat.ch/wiki/weewiki) | Computer Music, Audio Programming, Literate Programming, Food |
 | [Memento](https://m0wer.github.io/memento/) | [MkDocs](https://www.mkdocs.org/), [MkDocs Newsletter](https://lyz-code.github.io/mkdocs-newsletter/) | Python, GNU/Linux, DevOps, Flutter, traveling, cooking, ...|


### PR DESCRIPTION
brainfck.org is my personal Zettelkasten/Digital Garden build mainly on TiddlyWiki. However, I use ORG Mode and Emacs to actually write content. I host my content on Github and publish using netlify automatically. 