### PR TITLE
Add wilde-at-heart.garden

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,4 @@ See the [Theory, Philosophy, and Navel-gazing](https://github.com/MaggieAppleton
 | [Soren Bjornstad](https://zettelkasten.sorenbjornstad.com) | TiddlyWiki + homegrown scripts | Almost everything; emphasis on tech, reading, and how to live |
 | [Paul Batchelor](https://pbat.ch/wiki) | [WeeWiki](https://pbat.ch/wiki/weewiki) | Computer Music, Audio Programming, Literate Programming, Food |
 | [Memento](https://m0wer.github.io/memento/) | [MkDocs](https://www.mkdocs.org/), [MkDocs Newsletter](https://lyz-code.github.io/mkdocs-newsletter/) | Python, GNU/Linux, DevOps, Flutter, traveling, cooking, ...|
+| [Jay Colbert](https://wilde-at-heart.garden) | [Logseq](http://logseq.com), Hugo + [Logseq Schrodinger](https://github.com/sawhney17/logseq-schrodinger) | Digital Garden + Zettelkasten. Critical theory, library science, opera, film, knowledge management |


### PR DESCRIPTION
Updated README to include my digital garden.

Because my digital garden is via Logseq, I would also be interested in adding Logseq information (and maybe writing a how-to tutorial) to the README.