### PR TITLE
Add Craft Engineer digital garden and Obsidian Gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ See the [Theory, Philosophy, and Navel-gazing](https://github.com/MaggieAppleton
 | [Paul Batchelor](https://pbat.ch/wiki) | [WeeWiki](https://pbat.ch/wiki/weewiki) | Computer Music, Audio Programming, Literate Programming, Food |
 | [Memento](https://m0wer.github.io/memento/) | [MkDocs](https://www.mkdocs.org/), [MkDocs Newsletter](https://lyz-code.github.io/mkdocs-newsletter/) | Python, GNU/Linux, DevOps, Flutter, traveling, cooking, ...|
 | [Jacky Zhao](https://garden.jzhao.xyz) | [Quartz](https://quartz.jzhao.xyz) | Books, Cognitive Sciences, Education, Technology, and whatever else I happen to be reading |
+| [Craft Engineer](https://craftengineer.com) | Obsidian + Jekyll | Software engineering, DevOps, AI, productivity |
 
 ## Other digital garden compilations:
 
@@ -166,4 +167,4 @@ See the [Theory, Philosophy, and Navel-gazing](https://github.com/MaggieAppleton
 * [Richard Litt's compilation](https://github.com/RichardLitt/meta-knowledge)
 * [KasperZutterman's compilation](https://github.com/KasperZutterman/Second-Brain)
 * [Best-of Digital Gardens](https://github.com/lyz-code/best-of-digital-gardens)
-
+* [Obsidian Gallery](https://obsidian-gallery.craftengineer.com)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See the [Theory, Philosophy, and Navel-gazing](https://github.com/MaggieAppleton
 - [Simply Jekyll](https://simply-jekyll.netlify.app/posts/introduction-to-simply-jekyll) - A Jekyll theme with bidirectional links, sidenotes, and transclusion
 - [Digital Garden Jekyll Template](https://github.com/maximevaillancourt/digital-garden-jekyll-template) - A simple, clean jekyll template with bi-directional links
 - [Jekyll-Bonsai](https://github.com/manunamz/jekyll-bonsai) - A modern jekyll theme for semantically inclined digital gardeners.
-- [Jekyll Garden](https://github.com/Jekyll-Garden/jekyll-garden.github.io) - Clean Jekyll theme supporting bidirectional links. 
+- [Jekyll Garden](https://github.com/Jekyll-Garden/jekyll-garden.github.io) - Clean Jekyll theme supporting bidirectional links.
 - [Eleventy Garden](https://github.com/b3u/eleventy-garden) - A minimal template with backlinks, built in [Eleventy](https://11ty.dev)
 - [Foam](https://foambubble.github.io/foam/) - Roam-like personal note management and publishing system built inside VSCode
 - [Foamy NextJS](https://github.com/yenly/foamy-nextjs) - Basic Foam + NextJS with MDX starter for building a digital garden
@@ -101,70 +101,70 @@ See the [Theory, Philosophy, and Navel-gazing](https://github.com/MaggieAppleton
 
 ⭐️ = Featured; unique and exceptional examples
 
-| Gardener & Link | 🛠 Build Tools  | 🌿Note Themes |
-| -------------------- | ------------------ | ----------------- |
-| ⭐️ [Andy Matuschak](https://notes.andymatuschak.org/)  | The Mystery Andy System | Note-taking, education, tools for thought |
-| ⭐️ [Gwern](https://www.gwern.net/) | [JS, CSS, Hakyll, Haskell](https://www.gwern.net/About#tools) | Quantified self, spaced repetition, bitcoin |
-| ⭐️ [Azlen Elza](https://notes.azlen.me/g3tibyfv/)  | Notion + Python | Design, Conversational interfaces, Tools for thought
-| ⭐️ [Buster Benson](https://busterbenson.com/piles/) |  | Behaviour change, dialogue, systems thinking |
-| ⭐️ [Tom Critchlow](https://tomcritchlow.com/)   | Jekyll              |  Indie consulting         |
-| ⭐️ [Chris Aldrich](https://tw.boffosocko.com) |  TiddlyWiki + TiddlyBlink + TiddlyMap | Art of Memory, IndieWeb, humanities, commonplace books, thought spaces
-| ⭐️ [Gordon Brander](http://gordonbrander.com/pattern/) |  [Lettersmith](https://github.com/gordonbrander/lettersmith_py) | Design patterns, storytelling, systems
-| ⭐️ [Bill Seitz](http://webseitz.fluxent.com/wiki/) |  Flask/Python with [WikiFlux](http://webseitz.fluxent.com/wiki/WikiFlux) | Product management, startups, wiki theory, engineering |
-| ⭐️ [Alex Komoroske](https://thecompendium.cards/c/half-baked/) | [Cards Web](https://github.com/jkomoros/card-web) – a custom OS platform | Complexity theory, design, systems thinking |
-| ⭐️ [Nikita Voloboev](https://wiki.nikiv.dev/) | GitBook | Tool obsessed. Code, web dev, art. |
-| [Anne-Laure Le Cunff](https://www.mentalnodes.com/)    | TiddlyWiki   | Networked thinking, metacognition, evidence-based learning and self-education   |
-| [Shawn Wang](https://www.swyx.io/writing) | Sapper | Web development, writing, speaking
-| [Kevin Cummingham](https://kevincunningham.co.uk) |  Gatsby | Web development, React, AWS, GraphQL
-| [Maggie Appleton](https://maggieappleton.com/garden)   |  Next.js  | Anthropology, metaphors, visual explanations, and web development
-| [Chris Biscardi](https://www.christopherbiscardi.com/garden)   |  Sector / Toast?   | Web development, MDX, GraphQL, Gatsby
-| [Neil Mather](https://commonplace.doubleloop.net) |  Org-mode | Programming, politics, climate change |
-| [Wess Daniels](https://nurselog.online)   |  Tiddlywiki (Pre-Release 5.1.23)   | Culture and systems change, liberation theology, tech and pedagogy
-| [Aengus McMillin](https://aengusmcmillin.com/brain)  |  Gatsby |  Programming, Stoicism  |
-| [Joel Hooks](https://joelhooks.com/)  |  Gatsby + MDX  | Bootstrapping / indie-hacking, community building, web development
-| [Ian Jones](https://garden.ianjones.us/)  |  Gatsby  | Web development, Gatsby, Emacs
-| [Wayan Jimmy](https://notebook.wayanjimmy.xyz) |  Gatsby ([Hasura Gitbook Starter](https://github.com/hasura/gatsby-gitbook-starter)) | Coding, Learning notes
-| [Markus](https://re1.dev/wiki/) |  Eleventy | Design, linux, privacy
-| [Max Stoiber](https://notes.mxstbr.com/About_these_notes) |  The Mystery Andy System | React, web development
-| [Daniel Chapman](https://www.dschapman.com/notes) |  Gatsby | Books, Writing, Poetry
-| [Will Stedden](https://bonkerfield.org/) |  Custom coding a [side project](https://bonkerfield.org/2020/05/swale-garden-stream/) | Machine learning, automated language generation, quantum physics art, online transparency
-| [Salman Ansari](https://notes.salman.io/) | Gatsby | Start-ups, engineering |
-| [Fabien Benetou](https://fabien.benetou.fr/) | PmWiki (with plenty of extensions PHP/JS/NodeJS/WebXR/CSS/Processing/etc) | Everytyhing but particularly programming, tools, tools for thoughts |
-| [Waylon Walker](https://waylonwalker.com/notes) | Gatsby | python, data-engineering, coding, learning notes |
-| [Cristian Rojas](https://notes.crisrojas.com) | [Hugo Zettels theme](https://github.com/crisrojas/zettels)   | 🇪🇸 Drawing, coding, biology, introspection   |
-| [Chinarut Ruangchotvit](http://autobiography.chinarut.com) | TheBrain | autobiography, personal transformation |
-| [Steve Dondley](https://steve.dondley.com/notes/) | Jekyll, vimwiki | Tech, software, automation, some politics and issues |
-| [Scott Spence](https://scottspence.com/garden/) | Toast + MDX | Web development, MDX, GraphQL, Gatsby, styled-components  |
-| [Devine Lu Linvega](https://wiki.xxiivv.com) | C | Sailing, Design, Livecoding, Plan9 |
-| [Milkii Brewster](https://wiki.thingsandstuff.org) | MediaWiki | Various life and tech topics, mostly Linux and audio FOSS |
-| [Maxime Vaillancourt](https://maximevaillancourt.com/notes) | Jekyll ([open-source template](https://maximevaillancourt.com/blog/setting-up-your-own-digital-garden-with-jekyll)) | personal growth, ruby, web, linux |
-| [Andy Byers](https://notes.ajb.app)  |  Jekyll  |   notes on coding, note taking, personal knowledge management and other random thoughts.  |
-| [Abstractxan](https://abstractxan.xyz) | C++ ([Mizi](https://github.com/AbstractXan/Mizi)) | Tech, Art, Curating resources |
-| [Luciano Strika](https://strikingloo.github.io/wiki/) | Jekyll | Personal Wiki, Digital Garden. StrikingLoo's Haphazard Repository of Knowledge, Opinions and Trivia |
-| [Piotr Gaczkowski](https://garden.doomhammer.info) | Jekyll + Roam Research as backend | Book notes, Codex Vitae, cocktails, experiments |
-| [Tymon Zaniewski](https://garden.tymon-zaniewski.xyz) | Jekyll ([open-source template](https://maximevaillancourt.com/blog/setting-up-your-own-digital-garden-with-jekyll)) | personal wiki, DIY electronics, making music |
-| [Aquiles Carattino](https://www.aquiles.me) | Aqui Brain Dump | Science. Notes on books and papers. Technology Transfer. Working in Public |
-| [Yenly Ma](https://yenly.wtf) | [Foamy NextJS](https://github.com/yenly/foamy-nextjs) and NextJS with MDX | Digital garden of gardens. Learning and making in public. |
-| [Rosano](https://rosano.hmm.garden) | Hyperdraft + [Garden](https://hmm.garden) | Music / Design / Technology |
-| [Chase McCoy](https://chasem.co/notes) | Gatsby + MDX | Web development, CSS, design systems |
-| [Charlie Trochlil](https://blog.charlietrochlil.com) | Maxime's [jekyll template](https://maximevaillancourt.com/blog/setting-up-your-own-digital-garden-with-jekyll) | Learning, art, online spaces, baking |
-| [Hiran Venugopalan](https://hiran.in/notes) | Obsidian + Jekyll | Design, Branding, Business, Typography, Product |
-| [Vlad Sitalo](https://vlad.roam.garden/) | [Roam Garden](https://roam.garden/) | How to define code readability objectively? Applying SRS to all the things, Building Roam Garden |
-| [Joel Chan](https://joelchan.roam.garden/) | [Roam Garden](https://roam.garden/) | Knowledge synthesis, Scientific Creativity |
-| [Blue Book](https://lyz-code.github.io/blue-book/) | MkDocs | Python, DevOps, life automation, health, art, ...|
-| [Oshyan Greene](https://garden.oshyan.com) | Discourse | Productivity, Digital Gardening, Ideas, Reviews, and Recommendations |
-| [Clinton Boys](https://mtsolitary.com) | org-roam + Hugo | Writing, data science, math, life |
-| [David Ralph Lewis](https://notes.davidralphlewis.co.uk) | TiddlyWiki | Writing, poetry, wellbeing, psychology |
-| [Soren Bjornstad](https://zettelkasten.sorenbjornstad.com) | TiddlyWiki + homegrown scripts | Almost everything; emphasis on tech, reading, and how to live |
-| [Paul Batchelor](https://pbat.ch/wiki) | [WeeWiki](https://pbat.ch/wiki/weewiki) | Computer Music, Audio Programming, Literate Programming, Food |
-| [Memento](https://m0wer.github.io/memento/) | [MkDocs](https://www.mkdocs.org/), [MkDocs Newsletter](https://lyz-code.github.io/mkdocs-newsletter/) | Python, GNU/Linux, DevOps, Flutter, traveling, cooking, ...|
-| [Jacky Zhao](https://garden.jzhao.xyz) | [Quartz](https://quartz.jzhao.xyz) | Books, Cognitive Sciences, Education, Technology, and whatever else I happen to be reading |
-| [Craft Engineer](https://craftengineer.com) | Obsidian + Jekyll | Software engineering, DevOps, AI, productivity |
+| Gardener & Link                                                                       | 🛠 Build Tools                                                                                                       | 🌿Note Themes                                                                                       |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| ⭐️ [Andy Matuschak](https://notes.andymatuschak.org/)                                | The Mystery Andy System                                                                                             | Note-taking, education, tools for thought                                                           |
+| ⭐️ [Gwern](https://www.gwern.net/)                                                   | [JS, CSS, Hakyll, Haskell](https://www.gwern.net/About#tools)                                                       | Quantified self, spaced repetition, bitcoin                                                         |
+| ⭐️ [Azlen Elza](https://notes.azlen.me/g3tibyfv/)                                    | Notion + Python                                                                                                     | Design, Conversational interfaces, Tools for thought                                                |
+| ⭐️ [Buster Benson](https://busterbenson.com/piles/)                                  |                                                                                                                     | Behaviour change, dialogue, systems thinking                                                        |
+| ⭐️ [Tom Critchlow](https://tomcritchlow.com/)                                        | Jekyll                                                                                                              | Indie consulting                                                                                    |
+| ⭐️ [Chris Aldrich](https://tw.boffosocko.com)                                        | TiddlyWiki + TiddlyBlink + TiddlyMap                                                                                | Art of Memory, IndieWeb, humanities, commonplace books, thought spaces                              |
+| ⭐️ [Gordon Brander](http://gordonbrander.com/pattern/)                               | [Lettersmith](https://github.com/gordonbrander/lettersmith_py)                                                      | Design patterns, storytelling, systems                                                              |
+| ⭐️ [Bill Seitz](http://webseitz.fluxent.com/wiki/)                                   | Flask/Python with [WikiFlux](http://webseitz.fluxent.com/wiki/WikiFlux)                                             | Product management, startups, wiki theory, engineering                                              |
+| ⭐️ [Alex Komoroske](https://thecompendium.cards/c/half-baked/)                       | [Cards Web](https://github.com/jkomoros/card-web) – a custom OS platform                                            | Complexity theory, design, systems thinking                                                         |
+| ⭐️ [Nikita Voloboev](https://wiki.nikiv.dev/)                                        | GitBook                                                                                                             | Tool obsessed. Code, web dev, art.                                                                  |
+| [Anne-Laure Le Cunff](https://www.mentalnodes.com/)                                   | TiddlyWiki                                                                                                          | Networked thinking, metacognition, evidence-based learning and self-education                       |
+| [Shawn Wang](https://www.swyx.io/writing)                                             | Sapper                                                                                                              | Web development, writing, speaking                                                                  |
+| [Kevin Cummingham](https://kevincunningham.co.uk)                                     | Gatsby                                                                                                              | Web development, React, AWS, GraphQL                                                                |
+| [Maggie Appleton](https://maggieappleton.com/garden)                                  | Next.js                                                                                                             | Anthropology, metaphors, visual explanations, and web development                                   |
+| [Chris Biscardi](https://www.christopherbiscardi.com/garden)                          | Sector / Toast?                                                                                                     | Web development, MDX, GraphQL, Gatsby                                                               |
+| [Neil Mather](https://commonplace.doubleloop.net)                                     | Org-mode                                                                                                            | Programming, politics, climate change                                                               |
+| [Wess Daniels](https://nurselog.online)                                               | Tiddlywiki (Pre-Release 5.1.23)                                                                                     | Culture and systems change, liberation theology, tech and pedagogy                                  |
+| [Aengus McMillin](https://aengusmcmillin.com/brain)                                   | Gatsby                                                                                                              | Programming, Stoicism                                                                               |
+| [Joel Hooks](https://joelhooks.com/)                                                  | Gatsby + MDX                                                                                                        | Bootstrapping / indie-hacking, community building, web development                                  |
+| [Ian Jones](https://garden.ianjones.us/)                                              | Gatsby                                                                                                              | Web development, Gatsby, Emacs                                                                      |
+| [Wayan Jimmy](https://notebook.wayanjimmy.xyz)                                        | Gatsby ([Hasura Gitbook Starter](https://github.com/hasura/gatsby-gitbook-starter))                                 | Coding, Learning notes                                                                              |
+| [Markus](https://re1.dev/wiki/)                                                       | Eleventy                                                                                                            | Design, linux, privacy                                                                              |
+| [Max Stoiber](https://notes.mxstbr.com/About_these_notes)                             | The Mystery Andy System                                                                                             | React, web development                                                                              |
+| [Daniel Chapman](https://www.dschapman.com/notes)                                     | Gatsby                                                                                                              | Books, Writing, Poetry                                                                              |
+| [Will Stedden](https://bonkerfield.org/)                                              | Custom coding a [side project](https://bonkerfield.org/2020/05/swale-garden-stream/)                                | Machine learning, automated language generation, quantum physics art, online transparency           |
+| [Salman Ansari](https://notes.salman.io/)                                             | Gatsby                                                                                                              | Start-ups, engineering                                                                              |
+| [Fabien Benetou](https://fabien.benetou.fr/)                                          | PmWiki (with plenty of extensions PHP/JS/NodeJS/WebXR/CSS/Processing/etc)                                           | Everytyhing but particularly programming, tools, tools for thoughts                                 |
+| [Waylon Walker](https://waylonwalker.com/notes)                                       | Gatsby                                                                                                              | python, data-engineering, coding, learning notes                                                    |
+| [Cristian Rojas](https://notes.crisrojas.com)                                         | [Hugo Zettels theme](https://github.com/crisrojas/zettels)                                                          | 🇪🇸 Drawing, coding, biology, introspection                                                          |
+| [Chinarut Ruangchotvit](http://autobiography.chinarut.com)                            | TheBrain                                                                                                            | autobiography, personal transformation                                                              |
+| [Steve Dondley](https://steve.dondley.com/notes/)                                     | Jekyll, vimwiki                                                                                                     | Tech, software, automation, some politics and issues                                                |
+| [Scott Spence](https://scottspence.com/garden/)                                       | Toast + MDX                                                                                                         | Web development, MDX, GraphQL, Gatsby, styled-components                                            |
+| [Devine Lu Linvega](https://wiki.xxiivv.com)                                          | C                                                                                                                   | Sailing, Design, Livecoding, Plan9                                                                  |
+| [Milkii Brewster](https://wiki.thingsandstuff.org)                                    | MediaWiki                                                                                                           | Various life and tech topics, mostly Linux and audio FOSS                                           |
+| [Maxime Vaillancourt](https://maximevaillancourt.com/notes)                           | Jekyll ([open-source template](https://maximevaillancourt.com/blog/setting-up-your-own-digital-garden-with-jekyll)) | personal growth, ruby, web, linux                                                                   |
+| [Andy Byers](https://notes.ajb.app)                                                   | Jekyll                                                                                                              | notes on coding, note taking, personal knowledge management and other random thoughts.              |
+| [Abstractxan](https://abstractxan.xyz)                                                | C++ ([Mizi](https://github.com/AbstractXan/Mizi))                                                                   | Tech, Art, Curating resources                                                                       |
+| [Luciano Strika](https://strikingloo.github.io/wiki/)                                 | Jekyll                                                                                                              | Personal Wiki, Digital Garden. StrikingLoo's Haphazard Repository of Knowledge, Opinions and Trivia |
+| [Piotr Gaczkowski](https://garden.doomhammer.info)                                    | Jekyll + Roam Research as backend                                                                                   | Book notes, Codex Vitae, cocktails, experiments                                                     |
+| [Tymon Zaniewski](https://garden.tymon-zaniewski.xyz)                                 | Jekyll ([open-source template](https://maximevaillancourt.com/blog/setting-up-your-own-digital-garden-with-jekyll)) | personal wiki, DIY electronics, making music                                                        |
+| [Aquiles Carattino](https://www.aquiles.me)                                           | Aqui Brain Dump                                                                                                     | Science. Notes on books and papers. Technology Transfer. Working in Public                          |
+| [Yenly Ma](https://yenly.wtf)                                                         | [Foamy NextJS](https://github.com/yenly/foamy-nextjs) and NextJS with MDX                                           | Digital garden of gardens. Learning and making in public.                                           |
+| [Rosano](https://rosano.hmm.garden)                                                   | Hyperdraft + [Garden](https://hmm.garden)                                                                           | Music / Design / Technology                                                                         |
+| [Chase McCoy](https://chasem.co/notes)                                                | Gatsby + MDX                                                                                                        | Web development, CSS, design systems                                                                |
+| [Charlie Trochlil](https://blog.charlietrochlil.com)                                  | Maxime's [jekyll template](https://maximevaillancourt.com/blog/setting-up-your-own-digital-garden-with-jekyll)      | Learning, art, online spaces, baking                                                                |
+| [Hiran Venugopalan](https://hiran.in/notes)                                           | Obsidian + Jekyll                                                                                                   | Design, Branding, Business, Typography, Product                                                     |
+| [Vlad Sitalo](https://vlad.roam.garden/)                                              | [Roam Garden](https://roam.garden/)                                                                                 | How to define code readability objectively? Applying SRS to all the things, Building Roam Garden    |
+| [Joel Chan](https://joelchan.roam.garden/)                                            | [Roam Garden](https://roam.garden/)                                                                                 | Knowledge synthesis, Scientific Creativity                                                          |
+| [Blue Book](https://lyz-code.github.io/blue-book/)                                    | MkDocs                                                                                                              | Python, DevOps, life automation, health, art, ...                                                   |
+| [Oshyan Greene](https://garden.oshyan.com)                                            | Discourse                                                                                                           | Productivity, Digital Gardening, Ideas, Reviews, and Recommendations                                |
+| [Clinton Boys](https://mtsolitary.com)                                                | org-roam + Hugo                                                                                                     | Writing, data science, math, life                                                                   |
+| [David Ralph Lewis](https://notes.davidralphlewis.co.uk)                              | TiddlyWiki                                                                                                          | Writing, poetry, wellbeing, psychology                                                              |
+| [Soren Bjornstad](https://zettelkasten.sorenbjornstad.com)                            | TiddlyWiki + homegrown scripts                                                                                      | Almost everything; emphasis on tech, reading, and how to live                                       |
+| [Paul Batchelor](https://pbat.ch/wiki)                                                | [WeeWiki](https://pbat.ch/wiki/weewiki)                                                                             | Computer Music, Audio Programming, Literate Programming, Food                                       |
+| [Memento](https://m0wer.github.io/memento/)                                           | [MkDocs](https://www.mkdocs.org/), [MkDocs Newsletter](https://lyz-code.github.io/mkdocs-newsletter/)               | Python, GNU/Linux, DevOps, Flutter, traveling, cooking, ...                                         |
+| [Jacky Zhao](https://garden.jzhao.xyz)                                                | [Quartz](https://quartz.jzhao.xyz)                                                                                  | Books, Cognitive Sciences, Education, Technology, and whatever else I happen to be reading          |
+| [CraftEngineer.com](https://craftengineer.com?ref=MaggieAppleton%2Fdigital-gardeners) | Digital Garden Plugin for Obsidian                                                                                  | Software engineering, Leadership & team management, productivity                                    |
 
 ## Other digital garden compilations:
 
-* [Nikita's compilation](https://wiki.nikiv.dev/other/wiki-workflow#similar-wikis-i-liked)
-* [Richard Litt's compilation](https://github.com/RichardLitt/meta-knowledge)
-* [KasperZutterman's compilation](https://github.com/KasperZutterman/Second-Brain)
-* [Best-of Digital Gardens](https://github.com/lyz-code/best-of-digital-gardens)
-* [Obsidian Gallery](https://obsidian-gallery.craftengineer.com)
+- [Nikita's compilation](https://wiki.nikiv.dev/other/wiki-workflow#similar-wikis-i-liked)
+- [Richard Litt's compilation](https://github.com/RichardLitt/meta-knowledge)
+- [KasperZutterman's compilation](https://github.com/KasperZutterman/Second-Brain)
+- [Best-of Digital Gardens](https://github.com/lyz-code/best-of-digital-gardens)
+- [Obsidian Sites Gallery](https://jsifalda.link/3a6qn9X)


### PR DESCRIPTION
This PR adds two new resources:

1. Added Craft Engineer's digital garden (https://craftengineer.com) to the Digital Garden Directory
2. Added Obsidian Gallery (https://obsidian-gallery.craftengineer.com) to the "Other digital garden compilations" section

Both resources provide valuable additions to the obsidian community - Craft Engineer's garden focuses on software engineering, leadership & team management, and productivity topics, while the Obsidian Gallery serves as a great compilation of digital gardens specifically built with Obsidian.